### PR TITLE
Initial creation of allow done

### DIFF
--- a/public/directives/meanUpload.js
+++ b/public/directives/meanUpload.js
@@ -14,9 +14,16 @@ angular.module('mean.mean-upload').directive('meanUpload', function($upload) {
             $scope.onFileSelect = function($files) {
                 var files = [];
                 $scope.files = $files;
+                //If they specified an allows attribute, turn it into a regex
+                var typeMatch = (angular.isDefined(attrs.allow))? new RegExp(attrs.allow): null;
                 //$files: an array of files selected, each file has name, size, and type.
                 for (var i = 0; i < $files.length; i++) {
                     var file = $files[i];
+                    //If there is a regex, test it
+                    if (typeMatch && !typeMatch.test(file.type)) {
+                        console.log('File of type ' + file.type + ' is not allowed');
+                        continue;
+                    }
                     $scope.upload = $upload.upload({
                         url: 'meanUpload/upload',
                         headers: {

--- a/public/directives/meanUpload.js
+++ b/public/directives/meanUpload.js
@@ -19,7 +19,7 @@ angular.module('mean.mean-upload').directive('meanUpload', function($upload) {
                 if (angular.isDefined(attrs.allow)) {
                     list = attrs.allow.split(',');
                     //If the list is a length of one, check to see if it is a regex
-                    var checkRegex = /\/(.+)\/([gimy]*)$/;
+                    var checkRegex = /^\/(.+)\/([gimy]*)$/;
                     if (list.length === 1 && checkRegex.test(list[0])) {
                         var matches = checkRegex.exec(list[0]);
                         typeMatch = new RegExp(matches[1], matches[2]);

--- a/public/directives/meanUpload.js
+++ b/public/directives/meanUpload.js
@@ -15,7 +15,17 @@ angular.module('mean.mean-upload').directive('meanUpload', function($upload) {
                 var files = [];
                 $scope.files = $files;
                 //If they specified an allows attribute, turn it into a regex
-                var typeMatch = (angular.isDefined(attrs.allow))? new RegExp(attrs.allow): null;
+                var typeMatch, list;
+                if (angular.isDefined(attrs.allow)) {
+                    list = attrs.allow.split(',');
+                    //If the list is a length of one, check to see if it is a regex
+                    var checkRegex = /\/(.+)\/([gimy]*)$/;
+                    if (list.length === 1 && checkRegex.test(list[0])) {
+                        var matches = checkRegex.exec(list[0]);
+                        typeMatch = new RegExp(matches[1], matches[2]);
+                        list = null;
+                    }
+                }
                 //$files: an array of files selected, each file has name, size, and type.
                 for (var i = 0; i < $files.length; i++) {
                     var file = $files[i];
@@ -23,6 +33,10 @@ angular.module('mean.mean-upload').directive('meanUpload', function($upload) {
                     if (typeMatch && !typeMatch.test(file.type)) {
                         console.log('File of type ' + file.type + ' is not allowed');
                         continue;
+                    }
+                    else if (list && list.indexOf(file.type) < 0) {
+                        console.log('File of type ' + file.type + ' is not allowed');
+                        continue;  
                     }
                     $scope.upload = $upload.upload({
                         url: 'meanUpload/upload',


### PR DESCRIPTION
I am creating this pull request basically for discussion. I added the ability to have a new attribute on the directive called "allow" that will use the string specified (as a regex) to match the file types. If it does not match, it does not upload the file. I tested this with one of my own projects, but I am interested to know how others would want this to be implemented and how bad file types should be handled.
