### PR TITLE
Fixed a typo in installation command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The package provides a directive called mean-upload which renders the file picke
 
 ### Installation
 just go to the root of your meanio site and run:
-mean instal mean-uplaod
+`mean install mean-uplaod`
 
 ### Callbacks
 The package provides two callbacks:


### PR DESCRIPTION
Fixed a typo in installation command "mean instal mean-uplaod"
